### PR TITLE
カテゴリAPIのパスを /v1/market/categories に統一

### DIFF
--- a/src/main/kotlin/com/example/myapp/config/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/example/myapp/config/GlobalExceptionHandler.kt
@@ -12,6 +12,7 @@ import org.springframework.security.authentication.LockedException
 import org.springframework.security.core.AuthenticationException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.servlet.resource.NoResourceFoundException
 import java.time.LocalDateTime
 
 @RestControllerAdvice
@@ -49,6 +50,14 @@ class GlobalExceptionHandler {
     @ExceptionHandler(AccessDeniedException::class)
     fun handleAccessDeniedException(ex: AccessDeniedException): ResponseEntity<ErrorResponse> {
         return buildResponse(ErrorCode.AUTH_FORBIDDEN)
+    }
+
+    /**
+     * Static resource not found
+     */
+    @ExceptionHandler(NoResourceFoundException::class)
+    fun handleNoResourceFoundException(ex: NoResourceFoundException): ResponseEntity<ErrorResponse> {
+        return buildResponse(ErrorCode.RESOURCE_NOT_FOUND, listOf(ex.message ?: "Resource not found"))
     }
 
     /**

--- a/src/main/kotlin/com/example/myapp/controller/market/category/CategoryController.kt
+++ b/src/main/kotlin/com/example/myapp/controller/market/category/CategoryController.kt
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController
  * カテゴリーコントローラー
  */
 @RestController
-@RequestMapping("/v1/categories")
+@RequestMapping("/v1/market/categories")
 class CategoryController(
     private val getAllCategories: GetAllCategories
 ) {

--- a/src/main/kotlin/com/example/myapp/service/market/item/ItemService.kt
+++ b/src/main/kotlin/com/example/myapp/service/market/item/ItemService.kt
@@ -28,9 +28,10 @@ class ItemService(
             quantity = 1,
             // デフォルト値
             shippingPayerType = 0,
-            shippingMethodId = 1, // 仮
-            shippingDaysId = 1, // 仮
-            shippingOriginArea = 1, // 仮
+            // マスタ未投入環境でもDraft作成が失敗しないよう、配送系はnullで開始
+            shippingMethodId = null,
+            shippingDaysId = null,
+            shippingOriginArea = null,
             categoryId = null, 
             name = null,
             price = null,

--- a/src/main/resources/db/migration/V13__add_display_id_to_items.sql
+++ b/src/main/resources/db/migration/V13__add_display_id_to_items.sql
@@ -1,0 +1,18 @@
+-- -----------------------------------------------------
+-- Add display id to items for public item identifier
+-- -----------------------------------------------------
+ALTER TABLE t_items
+    ADD COLUMN f_display_id VARCHAR(32);
+
+-- Backfill existing rows with deterministic unique ids.
+UPDATE t_items
+SET f_display_id = 'G' || LPAD(f_item_id::text, 8, '0')
+WHERE f_display_id IS NULL;
+
+ALTER TABLE t_items
+    ALTER COLUMN f_display_id SET NOT NULL;
+
+ALTER TABLE t_items
+    ADD CONSTRAINT uq_items_display_id UNIQUE (f_display_id);
+
+CREATE INDEX idx_items_display_id ON t_items(f_display_id);

--- a/src/main/resources/db/migration/V14__seed_shipping_master_data.sql
+++ b/src/main/resources/db/migration/V14__seed_shipping_master_data.sql
@@ -1,0 +1,45 @@
+-- -----------------------------------------------------
+-- Seed shipping master data used by item draft/publish flows
+-- -----------------------------------------------------
+
+-- 配送方法マスタ
+INSERT INTO m_shipping_method (f_shipping_method_id, f_name, f_is_anonymous, f_is_tracking, f_allows_cool)
+SELECT 1, '未定', 0, 0, 0
+WHERE NOT EXISTS (
+    SELECT 1 FROM m_shipping_method WHERE f_shipping_method_id = 1
+);
+
+INSERT INTO m_shipping_method (f_shipping_method_id, f_name, f_is_anonymous, f_is_tracking, f_allows_cool)
+SELECT 2, '通常配送', 0, 1, 0
+WHERE NOT EXISTS (
+    SELECT 1 FROM m_shipping_method WHERE f_shipping_method_id = 2
+);
+
+INSERT INTO m_shipping_method (f_shipping_method_id, f_name, f_is_anonymous, f_is_tracking, f_allows_cool)
+SELECT 3, 'クール便', 0, 1, 1
+WHERE NOT EXISTS (
+    SELECT 1 FROM m_shipping_method WHERE f_shipping_method_id = 3
+);
+
+-- 発送日数マスタ
+INSERT INTO m_shipping_days (f_shipping_days_id, f_name, f_min_days, f_max_days)
+SELECT 1, '1~2日で発送', 1, 2
+WHERE NOT EXISTS (
+    SELECT 1 FROM m_shipping_days WHERE f_shipping_days_id = 1
+);
+
+INSERT INTO m_shipping_days (f_shipping_days_id, f_name, f_min_days, f_max_days)
+SELECT 2, '2~3日で発送', 2, 3
+WHERE NOT EXISTS (
+    SELECT 1 FROM m_shipping_days WHERE f_shipping_days_id = 2
+);
+
+INSERT INTO m_shipping_days (f_shipping_days_id, f_name, f_min_days, f_max_days)
+SELECT 3, '4~7日で発送', 4, 7
+WHERE NOT EXISTS (
+    SELECT 1 FROM m_shipping_days WHERE f_shipping_days_id = 3
+);
+
+-- SERIAL採番の整合を合わせる
+SELECT setval('m_shipping_method_f_shipping_method_id_seq', COALESCE((SELECT MAX(f_shipping_method_id) FROM m_shipping_method), 1), true);
+SELECT setval('m_shipping_days_f_shipping_days_id_seq', COALESCE((SELECT MAX(f_shipping_days_id) FROM m_shipping_days), 1), true);

--- a/src/main/resources/db/migration/V15__seed_categories.sql
+++ b/src/main/resources/db/migration/V15__seed_categories.sql
@@ -1,0 +1,57 @@
+-- -----------------------------------------------------
+-- Seed category master data
+-- -----------------------------------------------------
+
+-- Root categories
+INSERT INTO m_categories (f_category_id, f_name, f_parent_id, f_level, f_sort_order)
+SELECT 1, '野菜', NULL, 1, 10
+WHERE NOT EXISTS (SELECT 1 FROM m_categories WHERE f_category_id = 1);
+
+INSERT INTO m_categories (f_category_id, f_name, f_parent_id, f_level, f_sort_order)
+SELECT 2, '果物', NULL, 1, 20
+WHERE NOT EXISTS (SELECT 1 FROM m_categories WHERE f_category_id = 2);
+
+INSERT INTO m_categories (f_category_id, f_name, f_parent_id, f_level, f_sort_order)
+SELECT 3, '米・穀物', NULL, 1, 30
+WHERE NOT EXISTS (SELECT 1 FROM m_categories WHERE f_category_id = 3);
+
+-- Children: 野菜
+INSERT INTO m_categories (f_category_id, f_name, f_parent_id, f_level, f_sort_order)
+SELECT 101, '葉物野菜', 1, 2, 10
+WHERE NOT EXISTS (SELECT 1 FROM m_categories WHERE f_category_id = 101);
+
+INSERT INTO m_categories (f_category_id, f_name, f_parent_id, f_level, f_sort_order)
+SELECT 102, '根菜', 1, 2, 20
+WHERE NOT EXISTS (SELECT 1 FROM m_categories WHERE f_category_id = 102);
+
+INSERT INTO m_categories (f_category_id, f_name, f_parent_id, f_level, f_sort_order)
+SELECT 103, 'きのこ', 1, 2, 30
+WHERE NOT EXISTS (SELECT 1 FROM m_categories WHERE f_category_id = 103);
+
+-- Children: 果物
+INSERT INTO m_categories (f_category_id, f_name, f_parent_id, f_level, f_sort_order)
+SELECT 201, '柑橘類', 2, 2, 10
+WHERE NOT EXISTS (SELECT 1 FROM m_categories WHERE f_category_id = 201);
+
+INSERT INTO m_categories (f_category_id, f_name, f_parent_id, f_level, f_sort_order)
+SELECT 202, 'ベリー類', 2, 2, 20
+WHERE NOT EXISTS (SELECT 1 FROM m_categories WHERE f_category_id = 202);
+
+INSERT INTO m_categories (f_category_id, f_name, f_parent_id, f_level, f_sort_order)
+SELECT 203, 'りんご・梨', 2, 2, 30
+WHERE NOT EXISTS (SELECT 1 FROM m_categories WHERE f_category_id = 203);
+
+-- Children: 米・穀物
+INSERT INTO m_categories (f_category_id, f_name, f_parent_id, f_level, f_sort_order)
+SELECT 301, '白米', 3, 2, 10
+WHERE NOT EXISTS (SELECT 1 FROM m_categories WHERE f_category_id = 301);
+
+INSERT INTO m_categories (f_category_id, f_name, f_parent_id, f_level, f_sort_order)
+SELECT 302, '玄米', 3, 2, 20
+WHERE NOT EXISTS (SELECT 1 FROM m_categories WHERE f_category_id = 302);
+
+INSERT INTO m_categories (f_category_id, f_name, f_parent_id, f_level, f_sort_order)
+SELECT 303, '雑穀', 3, 2, 30
+WHERE NOT EXISTS (SELECT 1 FROM m_categories WHERE f_category_id = 303);
+
+SELECT setval('m_categories_f_category_id_seq', COALESCE((SELECT MAX(f_category_id) FROM m_categories), 1), true);


### PR DESCRIPTION
NoResourceFoundException を RESOURCE_NOT_FOUND(404) で返すハンドリングを追加 Draft作成時の配送関連デフォルト値を null に変更し、FK未投入環境での作成失敗を回避
t_items に f_display_id を追加し、既存データを採番バックフィルして NOT NULL / UNIQUE / index を設定 配送マスタ（m_shipping_method, m_shipping_days）の初期データ投入マイグレーションを追加 カテゴリマスタ（m_categories）の初期データ投入マイグレーションを追加